### PR TITLE
Match filename case for include.

### DIFF
--- a/src/CBUS.h
+++ b/src/CBUS.h
@@ -41,7 +41,7 @@
 #include <CBUSLED.h>
 #include <CBUSswitch.h>
 #include <CBUSconfig.h>
-#include <CBUSdefs.h>
+#include <cbusdefs.h>
 
 static const unsigned int SW_TR_HOLD = 6000;       // CBUS push button hold time for SLiM/FLiM transition in millis
 


### PR DESCRIPTION
Match filename case for cbusdefs.h include in CBUS.h (I am using Ubuntu and mismatch causes a compile error).